### PR TITLE
Detect if a module was extracted by extract-text-plugin

### DIFF
--- a/src/shared/buildHierarchy.js
+++ b/src/shared/buildHierarchy.js
@@ -8,12 +8,12 @@ export default function buildHierarchy(modules) {
     
     modules.forEach(function addToTree(module) {
         // remove this module if either:
-        // - duplicate/incorrect style-loader item
-        // - issued by extract-text-plugin, which means it was moved to a css file
-        if (module.identifier.indexOf('css-loader') !== -1) {
-            if (module.identifier.indexOf('style-loader') !== -1 || module.issuer.indexOf('extract-text-webpack-plugin') !== -1) {
-                return;
-            }
+        // - index is null
+        // - issued by extract-text-plugin
+        let extractInIdentifier = module.identifier.indexOf('extract-text-webpack-plugin') !== -1;
+        let extractInIssuer = module.issuer && module.issuer.indexOf('extract-text-webpack-plugin') !== -1;
+        if (extractInIdentifier || extractInIssuer || module.index === null) {
+            return;
         }
         
         let mod = {


### PR DESCRIPTION
Fixes #17 

The pattern that extract-textplugin adds to identifier or issuer is 'extract-text-webpack-plugin\\loader.js?{\"omit\":1,\"extract\":true,\"remove\":true}'

Since seems that is possible to not remove from the bundle given the `remove: true` param, to account for this situation it should be necessary to check also for the presence of `remove: true`.
