### PR TITLE
Decrease size of html

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -14,9 +14,18 @@ export default class VisualizerPlugin {
 
     apply(compiler) {
         compiler.plugin('emit', (compilation, callback) => {
-            let stats = compilation.getStats().toJson({chunkModules: true});
-            let stringifiedStats = JSON.stringify(stats);
-            stringifiedStats = stringifiedStats.replace(/</g, '&lt;').replace(/</g, '&gt;');
+            let stats = compilation.getStats().toJson({
+                hash: true,
+                version: true,
+                timings: true,
+                assets: true,
+                chunks: true,
+                chunkModules: true,
+                modules: true,
+                reasons: true,
+                source: false,
+            });
+            let stringifiedStats = JSON.stringify(stats).replace(/</g, '\\u003c');
 
             let html = `<!doctype html>
                 <meta charset="UTF-8">


### PR DESCRIPTION
* Only ask for stats that may be useful sometime
* Fix json escaping, using &lt; actually doesn't work in strings, you need to use unicode

This brought the html down from 17MB to 6MB for me.